### PR TITLE
patch u-boot to work with R4S 1GB DDR3 version

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -35,6 +35,17 @@ define U-Boot/nanopi-r2s-rk3328
   OF_PLATDATA:=$(1)
 endef
 
+define U-Boot/nanopi-r2c-rk3328
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R2C
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r2c
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r2c-rk3328:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3328_bl31.elf
+  OF_PLATDATA:=nanopi-r2s-rk3328
+endef
+
 
 # RK3399 boards
 
@@ -72,7 +83,8 @@ UBOOT_TARGETS := \
   nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
-  nanopi-r2s-rk3328
+  nanopi-r2s-rk3328 \
+  nanopi-r2c-rk3328
 
 UBOOT_CONFIGURE_VARS += USE_PRIVATE_LIBGCC=yes
 
@@ -92,6 +104,7 @@ ifneq ($(OF_PLATDATA),)
 endif
 
 	$(SED) 's#CONFIG_MKIMAGE_DTC_PATH=.*#CONFIG_MKIMAGE_DTC_PATH="$(PKG_BUILD_DIR)/scripts/dtc/dtc"#g' $(PKG_BUILD_DIR)/.config
+	echo 'CONFIG_IDENT_STRING=" OpenWrt"' >> $(PKG_BUILD_DIR)/.config
 endef
 
 define Build/InstallDev

--- a/package/boot/uboot-rockchip/patches/201-rockchip-rk3328-Add-support-for-NanoPi-R2C-Plus.patch
+++ b/package/boot/uboot-rockchip/patches/201-rockchip-rk3328-Add-support-for-NanoPi-R2C-Plus.patch
@@ -1,0 +1,203 @@
+From f45273d0067512dd6976f1e9f28396b937dccf06 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Fri, 31 Dec 2021 19:11:04 +0800
+Subject: [PATCH] rockchip: rk3328: Add support for NanoPi R2C (Plus)
+
+The only difference between R2C and R2S is the Ethernet PHY chip,
+and the R2C Plus has 8G eMMC Flash.
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/Makefile                      |  1 +
+ arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi |  7 ++
+ arch/arm/dts/rk3328-nanopi-r2c.dts         | 27 ++++++
+ board/rockchip/evb_rk3328/MAINTAINERS      |  7 ++
+ configs/nanopi-r2c-rk3328_defconfig        | 98 ++++++++++++++++++++++
+ 5 files changed, 140 insertions(+)
+ create mode 100644 arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3328-nanopi-r2c.dts
+ create mode 100644 configs/nanopi-r2c-rk3328_defconfig
+
+diff --git a/arch/arm/dts/Makefile b/arch/arm/dts/Makefile
+index 9fb38682e6..5c55c75175 100644
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -109,6 +109,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3308) += \
+ dtb-$(CONFIG_ROCKCHIP_RK3328) += \
+ 	rk3328-evb.dtb \
+ 	rk3328-nanopi-r2s.dtb \
++	rk3328-nanopi-r2c.dtb \
+ 	rk3328-roc-cc.dtb \
+ 	rk3328-rock64.dtb \
+ 	rk3328-rock-pi-e.dtb
+diff --git a/arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi b/arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi
+new file mode 100644
+index 0000000000..f087e7d9b5
+--- /dev/null
++++ b/arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi
+@@ -0,0 +1,7 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2021 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ */
++
++#include "rk3328-nanopi-r2s-u-boot.dtsi"
+diff --git a/arch/arm/dts/rk3328-nanopi-r2c.dts b/arch/arm/dts/rk3328-nanopi-r2c.dts
+new file mode 100644
+index 0000000000..34f339ca5f
+--- /dev/null
++++ b/arch/arm/dts/rk3328-nanopi-r2c.dts
+@@ -0,0 +1,27 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2021 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ */
++
++/dts-v1/;
++#include "rk3328-nanopi-r2s.dts"
++
++/ {
++	model = "FriendlyElec NanoPi R2C";
++	compatible = "friendlyarm,nanopi-r2c", "rockchip,rk3328";
++};
++
++&emmc {
++	bus-width = <8>;
++	cap-mmc-highspeed;
++	max-frequency = <150000000>;
++	mmc-ddr-1_8v;
++	mmc-hs200-1_8v;
++	non-removable;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_clk &emmc_cmd &emmc_bus8>;
++	vmmc-supply = <&vcc_io_33>;
++	vqmmc-supply = <&vcc18_emmc>;
++	status = "okay";
++};
+diff --git a/board/rockchip/evb_rk3328/MAINTAINERS b/board/rockchip/evb_rk3328/MAINTAINERS
+index 14fda46e8f..73cc8a1f0d 100644
+--- a/board/rockchip/evb_rk3328/MAINTAINERS
++++ b/board/rockchip/evb_rk3328/MAINTAINERS
+@@ -12,6 +12,13 @@ F:      configs/nanopi-r2s-rk3328_defconfig
+ F:      arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+ F:      arch/arm/dts/rk3328-nanopi-r2s.dts
+ 
++NANOPI-R2C-RK3328
++M:      jensen <jensenhuang@friendlyarm.com>
++S:      Maintained
++F:      configs/nanopi-r2c-rk3328_defconfig
++F:      arch/arm/dts/rk3328-nanopi-r2c-u-boot.dtsi
++F:      arch/arm/dts/rk3328-nanopi-r2c.dts
++
+ ROC-RK3328-CC
+ M:      Loic Devulder <ldevulder@suse.com>
+ M:      Chen-Yu Tsai <wens@csie.org>
+diff --git a/configs/nanopi-r2c-rk3328_defconfig b/configs/nanopi-r2c-rk3328_defconfig
+new file mode 100644
+index 0000000000..7bc7a3274f
+--- /dev/null
++++ b/configs/nanopi-r2c-rk3328_defconfig
+@@ -0,0 +1,98 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_SPL_GPIO_SUPPORT=y
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_DEFAULT_DEVICE_TREE="rk3328-nanopi-r2c"
++CONFIG_ROCKCHIP_RK3328=y
++CONFIG_TPL_ROCKCHIP_COMMON_BOARD=y
++CONFIG_TPL_LIBCOMMON_SUPPORT=y
++CONFIG_TPL_LIBGENERIC_SUPPORT=y
++CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
++CONFIG_SPL_STACK_R_ADDR=0x600000
++CONFIG_DEBUG_UART_BASE=0xFF130000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEBUG_UART=y
++CONFIG_TPL_SYS_MALLOC_F_LEN=0x800
++# CONFIG_ANDROID_BOOT_IMAGE is not set
++CONFIG_FIT=y
++CONFIG_FIT_VERBOSE=y
++CONFIG_SPL_LOAD_FIT=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3328-nanopi-r2c.dtb"
++# CONFIG_DISPLAY_CPUINFO is not set
++CONFIG_DISPLAY_BOARDINFO_LATE=y
++CONFIG_MISC_INIT_R=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_TPL_SYS_MALLOC_SIMPLE=y
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_I2C_SUPPORT=y
++CONFIG_SPL_POWER_SUPPORT=y
++CONFIG_SPL_ATF=y
++CONFIG_SPL_ATF_NO_PLATFORM_PARAM=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_TPL_OF_CONTROL=y
++CONFIG_OF_SPL_REMOVE_PROPS="clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_TPL_OF_PLATDATA=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_NET_RANDOM_ETHADDR=y
++CONFIG_TPL_DM=y
++CONFIG_REGMAP=y
++CONFIG_SPL_REGMAP=y
++CONFIG_TPL_REGMAP=y
++CONFIG_SYSCON=y
++CONFIG_SPL_SYSCON=y
++CONFIG_TPL_SYSCON=y
++CONFIG_CLK=y
++CONFIG_SPL_CLK=y
++CONFIG_FASTBOOT_BUF_ADDR=0x800800
++CONFIG_FASTBOOT_CMD_OEM_FORMAT=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_SF_DEFAULT_SPEED=20000000
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PINCTRL=y
++CONFIG_SPL_PINCTRL=y
++CONFIG_DM_PMIC=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_SPL_DM_REGULATOR=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_DM_REGULATOR_FIXED=y
++CONFIG_SPL_DM_REGULATOR_FIXED=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM=y
++CONFIG_SPL_RAM=y
++CONFIG_TPL_RAM=y
++CONFIG_DM_RESET=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSINFO=y
++CONFIG_SYSRESET=y
++# CONFIG_TPL_SYSRESET is not set
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_OHCI_HCD=y
++CONFIG_USB_OHCI_GENERIC=y
++CONFIG_USB_DWC2=y
++CONFIG_USB_DWC3=y
++# CONFIG_USB_DWC3_GADGET is not set
++CONFIG_USB_GADGET=y
++CONFIG_USB_GADGET_DWC2_OTG=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_TPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/300-rockchip-rk3328-Fix-spl-mmc-boot-device-ofpath.patch
+++ b/package/boot/uboot-rockchip/patches/300-rockchip-rk3328-Fix-spl-mmc-boot-device-ofpath.patch
@@ -1,0 +1,28 @@
+From e14e93922a39e5950c8b042aefd0c9869ee3a259 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Sat, 1 Jan 2022 18:41:34 +0800
+Subject: [PATCH 300/308] rockchip: rk3328: Fix spl mmc boot device ofpath
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/mach-rockchip/rk3328/rk3328.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm/mach-rockchip/rk3328/rk3328.c b/arch/arm/mach-rockchip/rk3328/rk3328.c
+index ec3336cb49..de17b88682 100644
+--- a/arch/arm/mach-rockchip/rk3328/rk3328.c
++++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
+@@ -21,8 +21,8 @@ DECLARE_GLOBAL_DATA_PTR;
+ #define FW_DDR_CON_REG		0xFF7C0040
+ 
+ const char * const boot_devices[BROM_LAST_BOOTSOURCE + 1] = {
+-	[BROM_BOOTSOURCE_EMMC] = "/rksdmmc@ff520000",
+-	[BROM_BOOTSOURCE_SD] = "/rksdmmc@ff500000",
++	[BROM_BOOTSOURCE_EMMC] = "/mmc@ff520000",
++	[BROM_BOOTSOURCE_SD] = "/mmc@ff500000",
+ };
+ 
+ static struct mm_region rk3328_mem_map[] = {
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/301-rockchip-dw_mmc-support-to-disable-HS-mode-for-SPL.patch
+++ b/package/boot/uboot-rockchip/patches/301-rockchip-dw_mmc-support-to-disable-HS-mode-for-SPL.patch
@@ -1,0 +1,31 @@
+From baecb10c4b34be29ca0aac97158d4cdbc84d76a0 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 1 Dec 2021 16:45:27 +0800
+Subject: [PATCH 301/308] rockchip: dw_mmc: support to disable HS mode for SPL
+
+For rk3399, the highspeed mode doesn't work because of
+the signal voltage remains at 1.8V after reboot.
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ drivers/mmc/rockchip_dw_mmc.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/drivers/mmc/rockchip_dw_mmc.c b/drivers/mmc/rockchip_dw_mmc.c
+index d7d5361fd5..49ad73fdff 100644
+--- a/drivers/mmc/rockchip_dw_mmc.c
++++ b/drivers/mmc/rockchip_dw_mmc.c
+@@ -145,6 +145,10 @@ static int rockchip_dwmmc_probe(struct udevice *dev)
+ 	}
+ #endif
+ 	dwmci_setup_cfg(&plat->cfg, host, priv->minmax[1], priv->minmax[0]);
++#ifdef CONFIG_SPL_BUILD
++	if (dev_read_bool(dev, "u-boot,spl-broken-hs"))
++		plat->cfg.host_caps &= ~MMC_MODE_HS;
++#endif
+ 	host->mmc = &plat->mmc;
+ 	host->mmc->priv = &priv->host;
+ 	host->mmc->dev = dev;
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/302-arm64-dts-rk3399-nanopi4-Add-u-boot-spl-broken-hs.patch
+++ b/package/boot/uboot-rockchip/patches/302-arm64-dts-rk3399-nanopi4-Add-u-boot-spl-broken-hs.patch
@@ -1,0 +1,24 @@
+From c608d2fd04cb4973f75082807e5df0653fc6e819 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 1 Dec 2021 18:20:37 +0800
+Subject: [PATCH 302/308] arm64: dts: rk3399-nanopi4: Add u-boot,spl-broken-hs
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3399-nanopi4-u-boot.dtsi | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm/dts/rk3399-nanopi4-u-boot.dtsi b/arch/arm/dts/rk3399-nanopi4-u-boot.dtsi
+index a9d10592d5..53c4f17ac8 100644
+--- a/arch/arm/dts/rk3399-nanopi4-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-nanopi4-u-boot.dtsi
+@@ -13,4 +13,6 @@
+ 
+ &sdmmc {
+ 	pinctrl-0 = <&sdmmc_bus4 &sdmmc_clk &sdmmc_cmd &sdmmc_cd>;
++
++	u-boot,spl-broken-hs;
+ };
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/303-rockchip-rk3328-add-mmc-aliases-for-nanopi-r2s.patch
+++ b/package/boot/uboot-rockchip/patches/303-rockchip-rk3328-add-mmc-aliases-for-nanopi-r2s.patch
@@ -1,0 +1,29 @@
+From b8d642fadf95508f3a728a995b6892467deb1097 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Tue, 4 Jan 2022 14:54:20 +0800
+Subject: [PATCH 303/308] rockchip: rk3328: add mmc aliases for nanopi-r2s
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi b/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+index 9e2ced1541..df692ec30a 100644
+--- a/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-nanopi-r2s-u-boot.dtsi
+@@ -7,6 +7,11 @@
+ #include "rk3328-u-boot.dtsi"
+ #include "rk3328-sdram-ddr4-666.dtsi"
+ / {
++	aliases {
++		mmc0 = &sdmmc;
++		mmc1 = &emmc;
++	};
++
+ 	chosen {
+ 		u-boot,spl-boot-order = "same-as-spl", &sdmmc, &emmc;
+ 	};
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/304-mmc-dw_mmc-Fixes-timeout-issue-for-FIFO-mode.patch
+++ b/package/boot/uboot-rockchip/patches/304-mmc-dw_mmc-Fixes-timeout-issue-for-FIFO-mode.patch
@@ -1,0 +1,36 @@
+From 6a662654973ff75baa44288829142eed4ed5a411 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Tue, 11 Jan 2022 16:22:04 +0800
+Subject: [PATCH 304/308] mmc: dw_mmc: Fixes timeout issue for FIFO mode
+
+Clearing the DTO interrupt should be unnecessary, and it would
+potentially result in never receiving this interrupt again.
+
+Do power-on or reset from uboot for a while can reproduce the issue:
+  dwmci_data_transfer: Timeout waiting for data!
+  mmc_load_image_raw_sector: mmc block read error
+
+Tested on NanoPi R4S with SanDisk Extreme PRO 32GB.
+
+Fixes: 8cb9d3ed3a ("mmc: dw_mmc: Fixes data read when receiving DTO interrupt in FIFO mode")
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ drivers/mmc/dw_mmc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/dw_mmc.c b/drivers/mmc/dw_mmc.c
+index a949dad574..8fa26b340b 100644
+--- a/drivers/mmc/dw_mmc.c
++++ b/drivers/mmc/dw_mmc.c
+@@ -168,7 +168,7 @@ static int dwmci_data_transfer(struct dwmci_host *host, struct mmc_data *data)
+ 			if (data->flags == MMC_DATA_READ &&
+ 			    (mask & (DWMCI_INTMSK_RXDR | DWMCI_INTMSK_DTO))) {
+ 				dwmci_writel(host, DWMCI_RINTSTS,
+-					     DWMCI_INTMSK_RXDR | DWMCI_INTMSK_DTO);
++					     DWMCI_INTMSK_RXDR);
+ 				while (size) {
+ 					ret = dwmci_fifo_ready(host,
+ 							DWMCI_FIFO_EMPTY,
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/305-common-bouncebuf-Add-arch_addr_aligned-hook-for-rk33.patch
+++ b/package/boot/uboot-rockchip/patches/305-common-bouncebuf-Add-arch_addr_aligned-hook-for-rk33.patch
@@ -1,0 +1,87 @@
+From 7b108ebc5f9ac82487ad17dea0ae7163285d906f Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 12 Jan 2022 10:59:31 +0800
+Subject: [PATCH 305/308] common: bouncebuf: Add arch_addr_aligned() hook for
+ rk3399
+
+As described in rk3399-u-boot.dtsi ("mmc to sram can't do dma"),
+this restrict can be sorted out by adding a hook and returning
+the non-DRAM area as Unaligned (0) in rk3399's implementation.
+
+Then we can enable DMA mode and save about 200ms of SPL boot.
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3399-u-boot.dtsi        |  3 ---
+ arch/arm/mach-rockchip/rk3399/rk3399.c | 13 +++++++++++++
+ common/bouncebuf.c                     |  9 +++++++--
+ 3 files changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/arch/arm/dts/rk3399-u-boot.dtsi b/arch/arm/dts/rk3399-u-boot.dtsi
+index 73922c328a..57e1a7feab 100644
+--- a/arch/arm/dts/rk3399-u-boot.dtsi
++++ b/arch/arm/dts/rk3399-u-boot.dtsi
+@@ -119,9 +119,6 @@
+ 
+ &sdmmc {
+ 	u-boot,dm-pre-reloc;
+-
+-	/* mmc to sram can't do dma, prevent aborts transferring TF-A parts */
+-	u-boot,spl-fifo-mode;
+ };
+ 
+ &spi1 {
+diff --git a/arch/arm/mach-rockchip/rk3399/rk3399.c b/arch/arm/mach-rockchip/rk3399/rk3399.c
+index 869d2159be..fc0292e6be 100644
+--- a/arch/arm/mach-rockchip/rk3399/rk3399.c
++++ b/arch/arm/mach-rockchip/rk3399/rk3399.c
+@@ -111,6 +111,19 @@ int arch_cpu_init(void)
+ 	return 0;
+ }
+ 
++int arch_addr_aligned(void *ubuf)
++{
++#define DRAM_END	0xf8000000
++
++	if ((uintptr_t)ubuf < DRAM_END) {
++		/* Aligned for DRAM area */
++		return 1;
++	}
++
++	debug("Unsupported buffer for DMA transfer\n");
++	return 0;
++}
++
+ #ifdef CONFIG_DEBUG_UART_BOARD_INIT
+ void board_debug_uart_init(void)
+ {
+diff --git a/common/bouncebuf.c b/common/bouncebuf.c
+index 6d98920de6..5f510a04ec 100644
+--- a/common/bouncebuf.c
++++ b/common/bouncebuf.c
+@@ -13,6 +13,12 @@
+ #include <bouncebuf.h>
+ #include <asm/cache.h>
+ 
++__weak int arch_addr_aligned(void *ubuf)
++{
++	/* Aligned */
++	return 1;
++}
++
+ static int addr_aligned(struct bounce_buffer *state)
+ {
+ 	const ulong align_mask = ARCH_DMA_MINALIGN - 1;
+@@ -29,8 +35,7 @@ static int addr_aligned(struct bounce_buffer *state)
+ 		return 0;
+ 	}
+ 
+-	/* Aligned */
+-	return 1;
++	return arch_addr_aligned(state->user_buffer);
+ }
+ 
+ int bounce_buffer_start_extalign(struct bounce_buffer *state, void *data,
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/306-arm64-rk3399-r4s-disable-nodes-for-vopb-vopl.patch
+++ b/package/boot/uboot-rockchip/patches/306-arm64-rk3399-r4s-disable-nodes-for-vopb-vopl.patch
@@ -1,0 +1,41 @@
+From 8a8b3ef12c68ad662223aefb4a46b1ca43e23482 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 12 Jan 2022 11:00:08 +0800
+Subject: [PATCH 306/308] arm64: rk3399: r4s: disable nodes for vopb/vopl
+
+Disable vopb and vopl to fix:
+  rk3399_vop vop@ff8f0000: failed to get ahb reset (ret=-524)
+  rk3399_vop vop@ff8f0000: failed to get ahb reset (ret=-524)
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3399-nanopi-r4s.dts | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm/dts/rk3399-nanopi-r4s.dts b/arch/arm/dts/rk3399-nanopi-r4s.dts
+index 6f2cf17bf1..e7c6daddd5 100644
+--- a/arch/arm/dts/rk3399-nanopi-r4s.dts
++++ b/arch/arm/dts/rk3399-nanopi-r4s.dts
+@@ -136,3 +136,19 @@
+ &vcc3v3_sys {
+ 	vin-supply = <&vcc5v0_sys>;
+ };
++
++&vopb {
++	status = "disabled";
++};
++
++&vopb_mmu {
++	status = "disabled";
++};
++
++&vopl {
++	status = "disabled";
++};
++
++&vopl_mmu {
++	status = "disabled";
++};
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/307-configs-Add-CONFIG_SYS_MMC_ENV_DEV-1-for-nanopi-r4s.patch
+++ b/package/boot/uboot-rockchip/patches/307-configs-Add-CONFIG_SYS_MMC_ENV_DEV-1-for-nanopi-r4s.patch
@@ -1,0 +1,25 @@
+From 92c1bcf0983464f7bcc9e38bc2a6edccc239bd93 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 12 Jan 2022 11:00:21 +0800
+Subject: [PATCH 307/308] configs: Add CONFIG_SYS_MMC_ENV_DEV=1 for nanopi-r4s
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ configs/nanopi-r4s-rk3399_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/nanopi-r4s-rk3399_defconfig b/configs/nanopi-r4s-rk3399_defconfig
+index 351d2eb553..0f22737d54 100644
+--- a/configs/nanopi-r4s-rk3399_defconfig
++++ b/configs/nanopi-r4s-rk3399_defconfig
+@@ -25,6 +25,7 @@ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
+ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_SYS_MMC_ENV_DEV=1
+ CONFIG_ROCKCHIP_GPIO=y
+ CONFIG_SYS_I2C_ROCKCHIP=y
+ CONFIG_MMC_DW=y
+-- 
+2.34.1
+

--- a/package/boot/uboot-rockchip/patches/308-rockchip-rk3328-Implement-arch_addr_aligned-hook.patch
+++ b/package/boot/uboot-rockchip/patches/308-rockchip-rk3328-Implement-arch_addr_aligned-hook.patch
@@ -1,0 +1,59 @@
+From 886a84ea1a0e501fd168ad779ca54aecc70f8f4d Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Wed, 12 Jan 2022 11:21:37 +0800
+Subject: [PATCH 308/308] rockchip: rk3328: Implement arch_addr_aligned() hook
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3328-u-boot.dtsi        |  6 ------
+ arch/arm/mach-rockchip/rk3328/rk3328.c | 13 +++++++++++++
+ 2 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/arch/arm/dts/rk3328-u-boot.dtsi b/arch/arm/dts/rk3328-u-boot.dtsi
+index 1633558264..d6b7f3e30a 100644
+--- a/arch/arm/dts/rk3328-u-boot.dtsi
++++ b/arch/arm/dts/rk3328-u-boot.dtsi
+@@ -52,16 +52,10 @@
+ 
+ &emmc {
+ 	u-boot,dm-pre-reloc;
+-
+-	/* mmc to sram can't do dma, prevent aborts transfering TF-A parts */
+-	u-boot,spl-fifo-mode;
+ };
+ 
+ &sdmmc {
+ 	u-boot,dm-pre-reloc;
+-
+-	/* mmc to sram can't do dma, prevent aborts transfering TF-A parts */
+-	u-boot,spl-fifo-mode;
+ };
+ 
+ &usb20_otg {
+diff --git a/arch/arm/mach-rockchip/rk3328/rk3328.c b/arch/arm/mach-rockchip/rk3328/rk3328.c
+index de17b88682..60e0b6134f 100644
+--- a/arch/arm/mach-rockchip/rk3328/rk3328.c
++++ b/arch/arm/mach-rockchip/rk3328/rk3328.c
+@@ -58,6 +58,19 @@ int arch_cpu_init(void)
+ 	return 0;
+ }
+ 
++int arch_addr_aligned(void *ubuf)
++{
++#define DRAM_END	0xff000000
++
++	if ((uintptr_t)ubuf < DRAM_END) {
++		/* Aligned for DRAM area */
++		return 1;
++	}
++
++	debug("Unsupported buffer for DMA transfer\n");
++	return 0;
++}
++
+ void board_debug_uart_init(void)
+ {
+ 	struct rk3328_grf_regs * const grf = (void *)GRF_BASE;
+-- 
+2.34.1
+


### PR DESCRIPTION
add u-boot patches from https://github.com/friendlyarm/friendlywrt
and from https://github.com/anaelorlinski/OpenWrt-NanoPi-R2S-R4S-Builds/commit/9d836044340ddef53f5d9f1946ac48c946a78284

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
