### PR TITLE
Update 40-net-smp-affinity

### DIFF
--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -33,9 +33,12 @@ friendlyarm,nanopi-r2s)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1" "xhci-hcd:usb3"
 	;;
-friendlyarm,nanopi-r4s)
+friendlyarm,nanopi-r4s|\
+friendlyelec,nanopi-r4s)
 	set_interface_core 10 "eth0"
+	echo 3f > /sys/class/net/eth0/queues/rx-0/rps_cpus
 	set_interface_core 20 "eth1"
+	echo 3f > /sys/class/net/eth1/queues/rx-0/rps_cpus
 	;;
 esac
 


### PR DESCRIPTION
Use load balance settings from: https://github.com/friendlyarm/friendlywrt/blob/master-v22.03/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity

irq of eth0 goes to core 4(hex 10) A72
irq of eth0 goes to core 5(hex 20) A72
queues are using all 6 cores with hex 3f

Thanks for explaining it xShARkx at OpenWrt forum

Signed-off-by: ManuVice <el.manu87@gmail.com>

Thanks for your contribution to OpenWrt!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://openwrt.org/submitting-patches

Please remove this message before posting the pull request.
